### PR TITLE
Build docs and push spec on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,24 @@ jobs:
       id: version
       run: |
         echo "::set-output name=tag::$(git describe --abbrev=0)"
-    # Build the plugin
+    # Build the plugin and docs
     - name: Build
       id: build
       run: |
         npm install
+        npm run build-docs --if-present
         npm run build --if-present
+
+    # Commit updated openapi.yaml back to the repository
+    - name: Commit docs
+      run: |
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+        git add docs/openapi.yaml
+        if ! git diff --cached --quiet; then
+          git commit -m "chore: update openapi.yaml [skip ci]"
+          git push origin HEAD:main
+        fi
     # Package the required files into a zip
     - name: Package
       run: |

--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ This project is forked from [coddingtonbear/obsidian-local-rest-api](https://git
 
 For instructions on integrating this plugin with GPTs, please see <https://github.com/bincyan/obsidian-chatgpt-gpts-integration>.
 
+## Release Process
+
+When a git tag is pushed, a GitHub Actions workflow will automatically build the
+plugin and regenerate `docs/openapi.yaml`. The workflow runs `npm run build-docs`
+before `npm run build` so that the latest OpenAPI specification is embedded in
+the release artifacts. After building, the workflow commits the updated
+`docs/openapi.yaml` back to the `main` branch so the repository always contains
+the newest spec.
+
+The build output (`main.js` with the bundled OpenAPI spec) is **not** committed
+to the repository. The workflow generates these files on the fly and uploads
+them as release assets.
+


### PR DESCRIPTION
## Summary
- regenerate docs and build during release
- commit updated `docs/openapi.yaml` back to `main`
- document automatic spec commit in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684834d2476c8323837bc83509e370aa