### PR TITLE
Fix CI install integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build
       id: build
       run: |
-        npm install
+        npm ci
         npm run build-docs --if-present
         npm run build --if-present
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,6 @@ jobs:
       with:
         node-version: '18'
     - name: Install modules
-      run: npm i
+      run: npm ci
     - name: Run tests
       run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1416,7 +1416,7 @@
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
-      "integrity": "sha512-hPyR0d3tCbcMDq/mkpZ4M7aS4pYtywJFnAQtQbIYNZlAbIYW/W2PASi6DPd7OJbRRqtD9h5pz50jdK4ZkZqX0w==",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
       "dev": true
     },
     "node_modules/@types/node": {


### PR DESCRIPTION
## Summary
- use `npm ci` in GitHub workflows for reproducible installs
- update `@types/js-yaml` integrity checksum

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485179d7548323b3b3d81001d39420