### PR TITLE
Fix jsonnet issue in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,17 +16,21 @@ jobs:
       with:
         node-version: '18.x' # You might need to adjust this value to your own version
     # Get the version number and put it in a variable
-    - name: Get Version
-      id: version
-      run: |
-        echo "::set-output name=tag::$(git describe --abbrev=0)"
-    # Build the plugin and docs
-    - name: Build
-      id: build
-      run: |
-        npm ci
-        npm run build-docs --if-present
-        npm run build --if-present
+      - name: Get Version
+        id: version
+        run: |
+          echo "::set-output name=tag::$(git describe --abbrev=0)"
+      - name: Install jsonnet
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jsonnet
+      # Build the plugin and docs
+      - name: Build
+        id: build
+        run: |
+          npm ci
+          npm run build-docs --if-present
+          npm run build --if-present
 
     # Commit updated openapi.yaml back to the repository
     - name: Commit docs


### PR DESCRIPTION
## Summary
- install jsonnet in GitHub release workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684857bd7ca08323abffa15019fa9fd2