### PR TITLE
Fix jsonnet openapi comma

### DIFF
--- a/docs/src/openapi.jsonnet
+++ b/docs/src/openapi.jsonnet
@@ -454,7 +454,7 @@ std.manifestYamlDoc(
           tags: [
             'Search',
           ],
-          summary: 'Search for documents matching a specified search query\n'
+          summary: 'Search for documents matching a specified search query\n',
           operationId: 'post_search',
           description: 'Evaluate a query against files in your vault. Provide the query in the request body using either Dataview DQL or JSON Logic, chosen via the `Content-Type` header.\n'
           requestBody: {


### PR DESCRIPTION
## Summary
- fix syntax error in `openapi.jsonnet`

## Testing
- `npm run build` *(fails: Cannot find type definitions)*
- `npm run build-docs` *(fails: jsonnet not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685388c0b4f083238a55f30325a73cdd